### PR TITLE
Fix secret key fallback

### DIFF
--- a/src/shared/lib/crypto.ts
+++ b/src/shared/lib/crypto.ts
@@ -1,9 +1,14 @@
 import CryptoJS from 'crypto-js';
 
 // 환경변수로부터 키 읽기 (32자 이상 권장)
-const SECRET_KEY = process.env.NEXT_PUBLIC_DANGLE_SECRET_KEY;
-if (!SECRET_KEY) {
-  throw new Error('Environment variable NEXT_PUBLIC_DANGLE_SECRET_KEY is not defined');
+const SECRET_KEY = process.env.NEXT_PUBLIC_DANGLE_SECRET_KEY ||
+  'DEFAULT_INSECURE_SECRET_KEY_CHANGE_ME';
+
+if (!process.env.NEXT_PUBLIC_DANGLE_SECRET_KEY) {
+  console.warn(
+    'Environment variable NEXT_PUBLIC_DANGLE_SECRET_KEY is not defined. ' +
+      'Using fallback key which should not be used in production.'
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid throwing when secret key environment variable is missing

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649f6a3f3083319d2b59c2a66f2ed2